### PR TITLE
Changed javaScriptDOMObjects and BrowserObjects to Constant.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -252,9 +252,9 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink javaScriptCssStyles            Label
 
   " Ajax Highlighting
-	HiLink javaScriptBrowserObjects     htmlString
+	HiLink javaScriptBrowserObjects     Constant
 
-	HiLink javaScriptDOMObjects         htmlString
+	HiLink javaScriptDOMObjects         Constant
 	HiLink javaScriptDOMMethods         Exception
 	HiLink javaScriptDOMProperties      Type
 


### PR DESCRIPTION
The reason I did this, was that javaScriptDOMObjects (document, event, ....) and javaScriptBrowserObjects (window, navigator, ...) were not highlighted on my system. I saw, that they were defined as              "htmlString" -  which made no sense to me. I have defined them as "Constant" now.
