### PR TITLE
This fixes the issue we discussed about semicolons.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -23,7 +23,7 @@ if version < 600 && exists("javaScript_fold")
   unlet javaScript_fold
 endif
 
-"" dollar sign is permittd anywhere in an identifier
+"" dollar sign is permitted anywhere in an identifier
 setlocal iskeyword+=$
 
 syntax sync fromstart


### PR DESCRIPTION
https://github.com/jelera/vim-javascript-syntax/issues/6#issuecomment-5665372

The logic for dealing with semicolons was wrong, particularly considering that two statements can appear on a single line. I think this fixes the issue, I don't think it will affect anything else.
