### PR TITLE
Remove code folding by default

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -201,8 +201,6 @@ function! JavaScriptFold()
 	setl foldtext=FoldText()
 endfunction
 
-au FileType javascript call JavaScriptFold()
-
 " }}}
 
 " Define the default highlighting.


### PR DESCRIPTION
This was removed in 2648939cbf66208a550170e18feb9728fe0fd8e7 by just reintroduced again in b03f40ff6ddf605ac146634a651632d6c1e8a50b.
