### PR TITLE
Removes dangling FoldText() call

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -202,8 +202,6 @@ function! JavaScriptFold()
 	setl foldmethod=syntax
 	setl foldlevelstart=1
 	syn region foldBraces start=/{/ end=/}/ transparent fold keepend extend
-
-	setl foldtext=FoldText()
 endfunction
 
 " }}}


### PR DESCRIPTION
Without this, fold comments were being displayed as:

```
+--  6 lines folded
```

... whereas, I'd expect something like:

```
+---  6 lines: .state('causes', {
```

... which this fix achieves. Should also resolve #14.
