### PR TITLE
Replace deprecated Bundle with Plugin in Vundle example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ NeoBundleLazy 'jelera/vim-javascript-syntax', {'autoload':{'filetypes':['javascr
   add this line to your `.vimrc`
 
 ```vim
-Bundle 'jelera/vim-javascript-syntax'
+Plugin 'jelera/vim-javascript-syntax'
 ```
 
 - Using [Pathogen](https://github.com/tpope/vim-pathogen),


### PR DESCRIPTION
Vundle is deprecating the the use of `Bundle`, `Plugin` should be used instead.
