### PR TITLE
Fix multiline strings.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -78,8 +78,8 @@ endif
 "}}}
 " Strings, Numbers and Regex Highlight {{{
 syntax match   javaScriptSpecial          "\\\d\d\d\|\\."
-syntax region  javaScriptString           start=+"+  skip=+\\\\\|\\"+  end=+"\|$+	contains=javaScriptSpecial,@htmlPreproc
-syntax region  javaScriptString           start=+'+  skip=+\\\\\|\\'+  end=+'\|$+	contains=javaScriptSpecial,@htmlPreproc
+syntax region  javaScriptString           start=+"+  skip=+\\\\\|\\"\|\\\n+  end=+"\|$+	contains=javaScriptSpecial,@htmlPreproc
+syntax region  javaScriptString           start=+'+  skip=+\\\\\|\\'\|\\\n+  end=+'\|$+	contains=javaScriptSpecial,@htmlPreproc
 
 syntax match   javaScriptSpecialCharacter "'\\.'"
 syntax match   javaScriptNumber           "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"


### PR DESCRIPTION
This enables multiline strings. Credit goes to [some guy named bigeasy](https://gist.github.com/bigeasy/3902914). Please merge!

NOTE: [javascript-libraries-syntax](https://github.com/othree/javascript-libraries-syntax.vim) breaks this, because they use the same rules as you for strings. If you want to try it out, uninstall `javascript-libraries-syntax`. Another pull request against their master branch is forthcoming :) 
