### PR TITLE
Adding basic ES6 string interpolation

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -182,6 +182,11 @@ syntax match javaScriptOpSymbols    "=\{1,3}\|!==\|!=\|<\|>\|>=\|<=\|++\|+=\|--\
 syntax match javaScriptEndColons    "[;,]"
 syntax match javaScriptLogicSymbols "\(&&\)\|\(||\)"
 "}}}
+" ES6 String Interpolation
+syntax match  javaScriptTemplateDelim    "\${\|}" contained
+syntax region javaScriptTemplateVar      start=+${+ end=+}+                        contains=javaScriptTemplateDelim keepend
+syntax region javaScriptTemplateString   start=+`+  skip=+\\\(`\|$\)+  end=+`+     contains=javaScriptTemplateVar,javaScriptSpecial keepend
+"}}}
 " JavaScriptFold Function {{{
 
 function! JavaScriptFold()


### PR DESCRIPTION
Syntax highlighting for ES6 string interpolation, adding:
```
javaScriptTemplateDelim - for matching delimiters ${ }
javaScriptTemplateVar - the variable part of interpolation ${...}
javaScriptTemplateString - everything between ` `
```

Example:
```
var test = "world";
var hello_world = `Hello ${test}`;
```