### PR TITLE
Support for object keys highlighting

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -174,7 +174,8 @@ syntax match   javaScriptFuncArg         "\(([^()]*)\)" contains=javaScriptParen
 syntax match   javaScriptFuncComma       /,/ contained
 syntax match   javaScriptFuncEq          /=/ contained
 syntax region  javaScriptFuncDef         start="\<function\>" end="\([^)]*\)" contains=javaScriptFuncKeyword,javaScriptFuncArg keepend
-syntax match jsFunctionKey /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function\s*\)\@=/ contained
+syntax match   javaScriptObjectKey       /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\)\@=/ contains=jsFunctionKey
+syntax match   javaScriptFunctionKey     /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function\s*\)\@=/ contained
 "}}}
 " Braces, Parens, symbols, colons {{{
 syntax match javaScriptBraces       "[{}\[\]]"

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -174,6 +174,7 @@ syntax match   javaScriptFuncArg         "\(([^()]*)\)" contains=javaScriptParen
 syntax match   javaScriptFuncComma       /,/ contained
 syntax match   javaScriptFuncEq          /=/ contained
 syntax region  javaScriptFuncDef         start="\<function\>" end="\([^)]*\)" contains=javaScriptFuncKeyword,javaScriptFuncArg keepend
+syntax match jsFunctionKey /\<[a-zA-Z_$][0-9a-zA-Z_$]*\>\(\s*:\s*function\s*\)\@=/ contained
 "}}}
 " Braces, Parens, symbols, colons {{{
 syntax match javaScriptBraces       "[{}\[\]]"


### PR DESCRIPTION
I've added support for syntax highlighting object keys of the form:

{
  key: value,
  key: function () {}
}