### PR TITLE
Function arguments can contain comments.

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -168,7 +168,7 @@ endif
 " Function and arguments highlighting {{{
 syntax keyword javaScriptFuncKeyword     function contained
 syntax region  javaScriptFuncExp         start=/\w\+\s\==\s\=function\>/ end="\([^)]*\)" contains=javaScriptFuncEq,javaScriptFuncKeyword,javaScriptFuncArg keepend
-syntax match   javaScriptFuncArg         "\(([^()]*)\)" contains=javaScriptParens,javaScriptFuncComma contained
+syntax match   javaScriptFuncArg         "\(([^()]*)\)" contains=javaScriptParens,javaScriptFuncComma,javaScriptComment contained
 syntax match   javaScriptFuncComma       /,/ contained
 syntax match   javaScriptFuncEq          /=/ contained
 syntax region  javaScriptFuncDef         start="\<function\>" end="\([^)]*\)" contains=javaScriptFuncKeyword,javaScriptFuncArg keepend


### PR DESCRIPTION
`/* b */`  isn't correctly highlighted on master:
```javascript
function foo(a, /* b */) {}
```

This commits makes it so that `javaScriptFuncArg` can contain comments in them to fix it